### PR TITLE
wikipediaからの文抽出方法を修正

### DIFF
--- a/src/utils/extract_sentences.py
+++ b/src/utils/extract_sentences.py
@@ -14,11 +14,10 @@ def extract_sentences(
         num_extract: int = 5) -> None:
     with gzip.open(output_path, "wt") as f:
         writer = csv.writer(f)
-        i = 0
         print(f"{datetime.datetime.now()}: Start")
         sys.stdout.flush()
-        for row in conceptnet:
-            # URI から entity を抽出
+
+        for i, row in enumerate(conceptnet):
             head = row[1]
             tail = row[2]
 
@@ -26,13 +25,12 @@ def extract_sentences(
             for sentence in corpus:
                 if head in sentence and tail in sentence:
                     sentences.append(sentence)
-                    if len(sentences) == num_extract:
-                        break
+                    # if len(sentences) == num_extract:
+                    #     break
 
             data = (row[0], head, tail, sentences)
             writer.writerow(data)
 
-            i += 1
             if i % 100 == 0:
                 sys.stdout.flush() # 明示的にflush
                 print(f"{datetime.datetime.now()}: {i} triplets have been processed.")
@@ -42,20 +40,20 @@ def extract_sentences(
 if __name__ == "__main__":
     # ConceptNetをロード
     lang = "ja"
-    dataset_type = "train"
+    dataset_type = "1"
     dataset_dir = f"datasets/conceptnet-assertions-5.7.0/{lang}"
-    input_file = f"{dataset_type}_triplets.csv"
+    input_file = f"triplets_{dataset_type}.csv"
     conceptnet_path = f"{dataset_dir}/{input_file}"
     conceptnet = fh.read_csv(conceptnet_path, has_header=False)
 
     # 日本語Wikipediaをロード
     corpus_dir = "datasets/jawiki-20221226"
-    input_corpus_path = f"{corpus_dir}/jawiki_sentences_1000.txt.gz"
+    input_corpus_path = f"{corpus_dir}/jawiki_sentences_200.txt.gz"
 
     print("Loading wikipedia corpus ...")
     with gzip.open(input_corpus_path, "rt") as f:
         corpus = f.readlines()
-    random.shuffle(corpus)
+    # random.shuffle(corpus)
 
     # # STAIR Captionsをロード
     # corpus_dir = "datasets/STAIR-captions"
@@ -65,7 +63,8 @@ if __name__ == "__main__":
     # with open(input_corpus_path, "r") as f:
     #     corpus = f.readlines()
 
-    output_corpus_path = f"{corpus_dir}/origin_rhts_{dataset_type}.csv.gz"
+    output_dir = "datasets/rel_gen/origin_rhts"
+    output_corpus_path = f"{output_dir}/origin_rhts_200_{dataset_type}.csv.gz"
 
     print("Extracting sentences ...")
     extract_sentences(output_path=output_corpus_path,

--- a/src/utils/extract_sentences.py
+++ b/src/utils/extract_sentences.py
@@ -37,6 +37,24 @@ def extract_sentences(
     print(f"Successfully dumped {output_path} !")
 
 
+# 抽出文がないものを除外し、文末の改行コードを除去
+def clean_sentences(input_path: str, output_path: str):
+    with gzip.open(input_path, 'rt') as f:
+        reader = csv.reader(f)
+
+    with gzip.open(output_path, 'wt') as f:
+        writer = csv.writer(f)
+        for i, row in enumerate(reader):
+            # 抽出文が無い場合新しいデータセットには記述しない
+            if row[-1] == "[]":
+                continue
+            else:
+                sentences = eval(row[-1])
+                cleaned_sentences = [sentence.rstrip('\n') for sentence in sentences]
+                writer.writerow((*row[:-1], cleaned_sentences))
+    print(f"Successfully dumped {output_path} !")
+
+
 if __name__ == "__main__":
     # ConceptNetをロード
     lang = "ja"
@@ -70,3 +88,8 @@ if __name__ == "__main__":
     extract_sentences(output_path=output_corpus_path,
                       corpus=corpus,
                       conceptnet=conceptnet)
+
+    print("Claning sentences ...")
+    cleaned_output_dir = "datasets/rel_gen/cleaned_rhts"
+    output_cleaned_path = f"{cleaned_output_dir}/cleaned_rhts_200_{dataset_type}.csv.gz"
+    clean_sentences(input_path=output_corpus_path, output_path=output_cleaned_path)

--- a/src/utils/preprocess_wiki.py
+++ b/src/utils/preprocess_wiki.py
@@ -7,50 +7,60 @@ import re
 from normalize_neologd import normalize_neologd, subtract_hashtag
 
 
+def article_to_sentences(input_corpus_path, output_corpus_path):
+    print(f"Loading {input_corpus_path}")
+    with gzip.open(input_corpus_path, "rt") as f:
+        wiki_corpus = f.readlines()
+
+    # クォーテーションマークで囲まれた部分を抽出する正規表現パターン
+    pattern = re.compile(r'「.+?」')
+
+    print(f"Dumping {output_corpus_path}")
+    sys.stdout.flush()
+    with gzip.open(output_corpus_path, "wt") as f:
+        for i, article in enumerate(wiki_corpus):
+            if i % 10000 == 0:
+                print(f"{datetime.datetime.now()}: {i} articles have been processed.")
+                sys.stdout.flush()
+
+            # 正規化
+            normalized_article = subtract_hashtag(normalize_neologd(article))
+            # クォーテーションマークで囲まれた部分を一時的に置換しておく
+            replaced_article = pattern.sub(lambda x: x.group().replace("。", "＠＠＠"), normalized_article)
+            # 「。」で改行する
+            sentences = replaced_article.split("。")
+            formatted_text = "\n".join(sentence.replace("＠＠＠", "。").strip() for sentence in sentences if sentence != "")
+            # 文末の「。」を削除する
+            formatted_text = formatted_text.rstrip("。")
+            # クォーテーションマークで囲まれた部分を元に戻す
+            sentence_list = pattern.sub(lambda x: x.group().replace("＠＠＠", "。"), formatted_text)
+            f.write(sentence_list)
+    print(f"Successfully dumped {output_corpus_path}")
+    sys.stdout.flush()
+
+
+def trim_sentence(input_path, output_path, limit=200):
+    with gzip.open(input_path, "rt") as rf:
+        with gzip.open(output_path, "wt") as wf:
+            for i, line in enumerate(rf):
+                if len(line) > limit:
+                    continue
+                else:
+                    wf.write(line[:limit])
+                if i % 10000 == 0:
+                    print(f"{datetime.datetime.now()}: {i} sentences have been processed.")
+                    sys.stdout.flush()
+    print(f"Successfully dumped {output_path}")
+
+
 corpus_dir = "datasets/jawiki-20221226"
 input_corpus_path = f"{corpus_dir}/jawiki_origin.txt.gz"
 output_corpus_path = f"{corpus_dir}/jawiki_sentences.txt.gz"
-
-print(f"Loading {input_corpus_path}")
-with gzip.open(input_corpus_path, "rt") as f:
-    wiki_corpus = f.readlines()
-
-# クォーテーションマークで囲まれた部分を抽出する正規表現パターン
-pattern = re.compile(r'「.+?」')
-
-print(f"Dumping {output_corpus_path}")
-sys.stdout.flush()
-with gzip.open(output_corpus_path, "wt") as f:
-    for i, article in enumerate(wiki_corpus):
-        if i % 10000 == 0:
-            print(f"{datetime.datetime.now()}: {i} articles has been processed.")
-            sys.stdout.flush()
-
-        # 正規化
-        normalized_article = subtract_hashtag(normalize_neologd(article))
-
-        # クォーテーションマークで囲まれた部分を一時的に置換しておく
-        replaced_article = pattern.sub(lambda x: x.group().replace("。", "＠＠＠"), normalized_article)
-
-        # 「。」で改行する
-        sentences = replaced_article.split("。")
-        formatted_text = "\n".join(sentence.replace("＠＠＠", "。").strip() for sentence in sentences if sentence != "")
-
-        # 文末の「。」を削除する
-        formatted_text = formatted_text.rstrip("。")
-
-        # クォーテーションマークで囲まれた部分を元に戻す
-        sentence_list = pattern.sub(lambda x: x.group().replace("＠＠＠", "。"), formatted_text)
-        f.write(sentence_list)
-
-print(f"Successfully dumped {output_corpus_path}")
+article_to_sentences(input_corpus_path, output_corpus_path)
 
 limit = 200
-output_1000_corpus_path = f"{corpus_dir}/jawiki_sentences_200.txt.gz"
-with gzip.open(output_corpus_path, "rt") as rf:
-    with gzip.open(output_1000_corpus_path, "wt") as wf:
-        for line in rf:
-            wf.write(line[:limit])
-            if len(line) > limit:
-                wf.write('\n')
+input_path = output_corpus_path
+output_path = f"{corpus_dir}/jawiki_sentences_200.txt.gz"
+trim_sentence(input_path, output_path)
+
 print("All done !")

--- a/src/utils/preprocess_wiki.py
+++ b/src/utils/preprocess_wiki.py
@@ -2,6 +2,7 @@ import gzip
 from tqdm import tqdm
 import datetime
 import sys
+import re
 
 from normalize_neologd import normalize_neologd, subtract_hashtag
 
@@ -14,22 +15,38 @@ print(f"Loading {input_corpus_path}")
 with gzip.open(input_corpus_path, "rt") as f:
     wiki_corpus = f.readlines()
 
+# クォーテーションマークで囲まれた部分を抽出する正規表現パターン
+pattern = re.compile(r'「.+?」')
+
 print(f"Dumping {output_corpus_path}")
 sys.stdout.flush()
 with gzip.open(output_corpus_path, "wt") as f:
-    i = 0
-    for article in wiki_corpus:
-        i += 1
+    for i, article in enumerate(wiki_corpus):
         if i % 10000 == 0:
             print(f"{datetime.datetime.now()}: {i} articles has been processed.")
             sys.stdout.flush()
-        sentence_list = subtract_hashtag(normalize_neologd(article)).split("。")
-        f.write("\n".join(sentence_list))
+
+        # 正規化
+        normalized_article = subtract_hashtag(normalize_neologd(article))
+
+        # クォーテーションマークで囲まれた部分を一時的に置換しておく
+        replaced_article = pattern.sub(lambda x: x.group().replace("。", "＠＠＠"), normalized_article)
+
+        # 「。」で改行する
+        sentences = replaced_article.split("。")
+        formatted_text = "\n".join(sentence.replace("＠＠＠", "。").strip() for sentence in sentences if sentence != "")
+
+        # 文末の「。」を削除する
+        formatted_text = formatted_text.rstrip("。")
+
+        # クォーテーションマークで囲まれた部分を元に戻す
+        sentence_list = pattern.sub(lambda x: x.group().replace("＠＠＠", "。"), formatted_text)
+        f.write(sentence_list)
 
 print(f"Successfully dumped {output_corpus_path}")
 
-limit = 1000
-output_1000_corpus_path = f"{corpus_dir}/jawiki_sentences_1000.txt.gz"
+limit = 200
+output_1000_corpus_path = f"{corpus_dir}/jawiki_sentences_200.txt.gz"
 with gzip.open(output_corpus_path, "rt") as rf:
     with gzip.open(output_1000_corpus_path, "wt") as wf:
         for line in rf:

--- a/src/utils/redistribute_dataset.py
+++ b/src/utils/redistribute_dataset.py
@@ -1,0 +1,77 @@
+import gzip
+import csv
+from sklearn.model_selection import train_test_split
+import random
+import sys
+
+
+# 参照. datasets/conceptnet-assertions-5.7.0/ja/relations.csv
+relations_data_path = "datasets/conceptnet-assertions-5.7.0/ja/relations.csv"
+with open(relations_data_path, "r") as f:
+    reader = csv.reader(f)
+    all_data = {}
+    for row in reader:
+        all_data[row[2]] = []
+
+input_dir = "datasets/rel_gen/cleaned_rhts"
+old_paths = [f"{input_dir}/cleaned_rhts_200_1.csv.gz",
+                   f"{input_dir}/cleaned_rhts_200_2.csv.gz",
+                   f"{input_dir}/cleaned_rhts_200_3.csv.gz",
+                   f"{input_dir}/cleaned_rhts_200_4.csv.gz",
+                   ]
+
+new_train_data = []
+new_val_data = []
+new_test_data = []
+
+for old_path in old_paths:
+    with gzip.open(old_path, 'rt') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if row[3] == "[]":
+                continue
+            elif row[0] == "関連する":
+                new_test_data.append(row)
+            else:
+                all_data[row[0]].append(row)
+
+for relation, data in all_data.items():
+    if len(data) < 1:
+            continue
+    train, val_and_test = train_test_split(data,
+                                           train_size=0.8,
+                                           test_size=0.2,
+                                           shuffle=True,
+                                           random_state=19990429)
+    if len(val_and_test) < 2:
+            continue
+    val, test = train_test_split(val_and_test,
+                                 train_size=0.5,
+                                 test_size=0.5,
+                                 shuffle=True,
+                                 random_state=19990429)
+    new_train_data.extend(train)
+    new_val_data.extend(val)
+    new_test_data.extend(test)
+
+random.shuffle(new_train_data)
+random.shuffle(new_val_data)
+random.shuffle(new_test_data)
+
+output_dir = "datasets/rel_gen/redistributed_rhts"
+new_train_path = f"{output_dir}/rhts_200_train.csv.gz"
+new_val_path = f"{output_dir}/rhts_200_val.csv.gz"
+new_test_path = f"{output_dir}/rhts_200_test.csv.gz"
+
+with gzip.open(new_train_path, "wt") as f:
+    writer = csv.writer(f)
+    writer.writerows(new_train_data)
+
+with gzip.open(new_val_path, "wt") as f:
+    writer = csv.writer(f)
+    writer.writerows(new_val_data)
+
+with gzip.open(new_test_path, "wt") as f:
+    writer = csv.writer(f)
+    writer.writerows(new_test_data)
+


### PR DESCRIPTION
# やったこと
- 今までは句点`。`を単純に`\n`に置換していたが、「」内の句点は無視するようにした
- 文長が200を超えるものは文抽出用コーパスに含めないようにした（このおかげで文抽出時間が大幅に削減）
- 結果的に文抽出用のコーパスは全部で`41,234,871`文から構成されている