### PR TITLE
Juman++でトークナイズできる環境を構築

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,6 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     build-essential ca-certificates software-properties-common \
     nano vim wget curl file git make xz-utils kmod pipenv locales task-japanese
 
-# 下記からCUDA Toolkitをダウンロード (Debian 11.7, CUDA 11.7)
-# https://developer.nvidia.com/cuda-11-7-1-download-archive
-RUN wget https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda-repo-debian11-11-7-local_11.7.1-515.65.01-1_amd64.deb && \
-    dpkg -i cuda-repo-debian11-11-7-local_11.7.1-515.65.01-1_amd64.deb && \
-    cp /var/cuda-repo-debian11-11-7-local/cuda-*-keyring.gpg /usr/share/keyrings/ && \
-    add-apt-repository contrib && \
-    apt-get update -y && \
-    apt-get install -y cuda --no-install-recommends cuda
-
 # 京都大学BARTの環境構築
 # Dev env for KU-BART
 COPY fairseq ./fairseq/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# FROM nvidia/cuda:11.7.1-cudnn8-devel-ubuntu22.04
-FROM python:3.9-bullseye
+FROM kunlp/jumanpp
 USER root
 
 # 環境変数を定義
@@ -10,27 +9,5 @@ ENV LANG=ja_JP.UTF-8 LANGUAGE=ja_JP:ja LC_ALL=ja_JP.UTF-8 \
 
 WORKDIR /work/tomishima2904/explore_conceptnet
 
-# Define the user and the group
-ARG USERNAME=tomishima2904 \
-    USER_UID=1098 \
-    USER_GID=1000
-
-# docker image に上記変数で定義したユーザーが存在しない場合、ユーザーを登録
-# If the user defiend above does not exists, add this
-RUN if ! id -u $USERNAME > /dev/null 2>&1; then \
-        groupadd --gid $USER_GID $USERNAME && \
-        useradd --uid $USER_UID --gid $USER_GID -m $USERNAME; \
-    fi
-
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
-    build-essential ca-certificates software-properties-common \
-    nano vim wget curl file git make xz-utils kmod pipenv locales task-japanese
-
-# 京都大学BARTの環境構築
-# Dev env for KU-BART
-COPY fairseq ./fairseq/
-RUN python -V && cd fairseq && pipenv install && cd ../
-
-# コンテナ内でルートユーザーとしてのみ振る舞いたいなら以下を消す
-# Delete line below if you want to play as root
-USER $USERNAME
+RUN apk update && apk add \
+    python3 python3-dev py3-pip alpine-sdk nano vim wget curl file git make

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG=ja_JP.UTF-8 LANGUAGE=ja_JP:ja LC_ALL=ja_JP.UTF-8 \
     TZ=JST-9 TERM=xterm PYTHONIOENCODING=utf-8 \
     DEBIAN_FRONTEND=noninteractive
 
-WORKDIR /mnt/tomishima2904/word2box
+WORKDIR /work/tomishima2904/explore_conceptnet
 
 # Define the user and the group
 ARG USERNAME=tomishima2904 \
@@ -29,7 +29,7 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
 # 京都大学BARTの環境構築
 # Dev env for KU-BART
 COPY fairseq ./fairseq/
-RUN python -V && cd fairseq && pipenv install
+RUN python -V && cd fairseq && pipenv install && cd ../
 
 # コンテナ内でルートユーザーとしてのみ振る舞いたいなら以下を消す
 # Delete line below if you want to play as root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# FROM nvidia/cuda:11.7.1-cudnn8-devel-ubuntu22.04
+FROM python:3.9-bullseye
+USER root
+
+# 環境変数を定義
+# Define env vars
+ENV LANG=ja_JP.UTF-8 LANGUAGE=ja_JP:ja LC_ALL=ja_JP.UTF-8 \
+    TZ=JST-9 TERM=xterm PYTHONIOENCODING=utf-8 \
+    DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /mnt/tomishima2904/word2box
+
+# Define the user and the group
+ARG USERNAME=tomishima2904 \
+    USER_UID=1098 \
+    USER_GID=1000
+
+# docker image に上記変数で定義したユーザーが存在しない場合、ユーザーを登録
+# If the user defiend above does not exists, add this
+RUN if ! id -u $USERNAME > /dev/null 2>&1; then \
+        groupadd --gid $USER_GID $USERNAME && \
+        useradd --uid $USER_UID --gid $USER_GID -m $USERNAME; \
+    fi
+
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+    build-essential ca-certificates software-properties-common \
+    nano vim wget curl file git make xz-utils kmod pipenv locales task-japanese
+
+# 下記からCUDA Toolkitをダウンロード (Debian 11.7, CUDA 11.7)
+# https://developer.nvidia.com/cuda-11-7-1-download-archive
+RUN wget https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda-repo-debian11-11-7-local_11.7.1-515.65.01-1_amd64.deb && \
+    dpkg -i cuda-repo-debian11-11-7-local_11.7.1-515.65.01-1_amd64.deb && \
+    cp /var/cuda-repo-debian11-11-7-local/cuda-*-keyring.gpg /usr/share/keyrings/ && \
+    add-apt-repository contrib && \
+    apt-get update -y && \
+    apt-get install -y cuda --no-install-recommends cuda
+
+# 京都大学BARTの環境構築
+# Dev env for KU-BART
+COPY fairseq ./fairseq/
+RUN python -V && cd fairseq && pipenv install
+
+# コンテナ内でルートユーザーとしてのみ振る舞いたいなら以下を消す
+# Delete line below if you want to play as root
+USER $USERNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,23 @@ USER root
 # 環境変数を定義
 # Define env vars
 ENV LANG=ja_JP.UTF-8 LANGUAGE=ja_JP:ja LC_ALL=ja_JP.UTF-8 \
-    TZ=JST-9 TERM=xterm PYTHONIOENCODING=utf-8 \
-    DEBIAN_FRONTEND=noninteractive
+    TZ=JST-9 TERM=xterm PYTHONIOENCODING=utf-8
 
 WORKDIR /work/tomishima2904/explore_conceptnet
 
+# 上から, python関連, build関連, その他パッケージ, rust, pipのupgrade, cargoへのパス通し
 RUN apk update && apk add \
-    python3 python3-dev py3-pip alpine-sdk nano vim wget curl file git make
+    python3 python3-dev py3-pip \
+    alpine-sdk openssl-dev make cmake libgomp \
+    nano vim wget curl file git \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && pip install --upgrade pip \
+    && echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $HOME/.profile
+
+# ~/.cargo/bin へのパスを通して cargo・rustc・rustup等を使えるようにする
+# 上記パッケージをインストールしないとtransformersが pip install できないため
+ENV PATH="/root/.cargo/bin:$PATH"
+
+# 下記リンクを参考にpytorchをインストール
+# https://pytorch.org/get-started/locally/
+RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
   #   env_file: ./.env
   #   ports:
   #     - 3307:3307
-  ku-bart:
-    container_name: ku-bart
+  juman:
+    container_name: juman-ku-bart
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,6 @@
 version: '3'
 
 services:
-  # db:
-  #   container_name: mysql-ku-bart
-  #   image: mysql:8
-  #   env_file: ./.env
-  #   ports:
-  #     - 3307:3307
   juman:
     container_name: juman-ku-bart
     build:
@@ -17,8 +11,6 @@ services:
     volumes:
       - /work/tomishima2904/explore_conceptnet:/work/tomishima2904/explore_conceptnet
     ports:
-      - '4416:4416'
+      - '4417:4417'
     stdin_open: true
     tty: true
-    # depends_on:
-    #   - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  # db:
+  #   container_name: mysql-ku-bart
+  #   image: mysql:8
+  #   env_file: ./.env
+  #   ports:
+  #     - 3307:3307
+  ku-bart:
+    container_name: ku-bart
+    build:
+      context: .
+      dockerfile: Dockerfile
+      network: host
+      shm_size: 80gb
+    volumes:
+      - /work/tomishima2904/explore_conceptnet:/work/tomishima2904/explore_conceptnet
+    ports:
+      - '4416:4416'
+    stdin_open: true
+    tty: true
+    # depends_on:
+    #   - db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+transformers
+rhoknp
+sentencepiece


### PR DESCRIPTION
# やったこと

- dockerでJuman++を使える環境を構築 41f3894bb35cc71e1ae4c62f28d7cf787a903706
- tokenizerに早稲田のRoBERTaのやつを使える！

# 参考文献
- [https://github.com/utanaka2000/fairseq](https://github.com/utanaka2000/fairseq)
- [https://github.com/ku-nlp/jumanpp](https://github.com/ku-nlp/jumanpp)
- [https://huggingface.co/ku-nlp/bart-base-japanese](https://huggingface.co/ku-nlp/bart-base-japanese)
- [https://hub.docker.com/r/kunlp/jumanpp](https://hub.docker.com/r/kunlp/jumanpp) こちらのイメージを使用 (linux-alpine)
- [nlp-waseda/roberta-base-japanese-with-auto-jumanpp](https://huggingface.co/nlp-waseda/roberta-base-japanese-with-auto-jumanpp)
- [https://github.com/ku-nlp/rhoknp](https://github.com/ku-nlp/rhoknp) 早稲田のTokenizerを使うのに必要
- [Install Rust](https://www.rust-lang.org/tools/install)

# 環境
``` 
# jumanpp --version
Juman++ Version: 2.0.0-d1 / Dictionary: 20210715-14b97cb / LM: K:20210809-0011280 L:20210116-10aab9fb F:20171214-9d125cb

rhoknp==1.3.2
sentencepiece==0.1.99
torch==1.13.1+cpu
transformers==4.30.1

# rustc --version
rustc 1.70.0 (90c541806 2023-05-31)

# rustup --version
rustup 1.26.0 (2023-04-05)

# cargo --version
cargo 1.70.0 (ec8a8a0ca 2023-04-25)
```