### PR TITLE
fix: コンテナ内userを追加するために、shadowを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /work/tomishima2904/explore_conceptnet
 RUN apk update && apk add \
     python3 python3-dev py3-pip \
     alpine-sdk openssl-dev make cmake libgomp \
-    nano vim wget curl file git \
+    nano vim wget curl file git shadow \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && pip install --upgrade pip \
     && echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $HOME/.profile
@@ -21,6 +21,25 @@ RUN apk update && apk add \
 # 上記パッケージをインストールしないとtransformersが pip install できないため
 ENV PATH="/root/.cargo/bin:$PATH"
 
+COPY requirements.txt ./
+
 # 下記リンクを参考にpytorchをインストール
 # https://pytorch.org/get-started/locally/
-RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu \
+    && pip install -r requirements.txt
+
+# Define the user and the group
+ARG USERNAME=tomishima2904 \
+    USER_UID=1098 \
+    USER_GID=1000
+
+# docker image に上記変数で定義したユーザーが存在しない場合、ユーザーを登録
+# If the user defiend above does not exists, add this
+RUN if ! id -u $USERNAME > /dev/null 2>&1; then \
+        groupadd --gid $USER_GID $USERNAME && \
+        useradd --uid $USER_UID --gid $USER_GID -m $USERNAME; \
+    fi
+
+# コンテナ内でルートユーザーとしてのみ振る舞いたいなら以下を消す
+# Delete line below if you want to play as root
+USER $USERNAME


### PR DESCRIPTION
- #15 
- rootで振る舞うのは権限系がやっぱりめんどくさいので修正
- apkの場合、`shadow`というパッケージを使うらしい
- requirementsも一緒に読み込むことにした（イメージのbuildに時間がかかるが...）