### PR TITLE
抽出文に上限を設け、重複を排除

### DIFF
--- a/src/preprocess_dataset/clean_sentences.py
+++ b/src/preprocess_dataset/clean_sentences.py
@@ -8,7 +8,7 @@ import sys
 def clean_sentences(input_path: str, output_path: str, err_path: str):
     with gzip.open(input_path, 'rt') as rf, \
         gzip.open(output_path, 'wt') as wf, \
-        open(err_path, 'w') as ef:
+        gzip.open(err_path, 'wt') as ef:
         reader = csv.reader(rf)
         writer = csv.writer(wf)
         err_writer = csv.writer(ef)

--- a/src/preprocess_dataset/clean_sentences.py
+++ b/src/preprocess_dataset/clean_sentences.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
     input_path = f"{input_dir}/origin_rhts_200_{dataset_type}.csv.gz"
     output_dir = "datasets/rel_gen/cleaned_rhts"
     output_path = f"{output_dir}/cleaned_rhts_200_{dataset_type}.csv.gz"
+    err_path = f"{output_dir}/cleaned_rhts_200_{dataset_type}_error.csv.gz"
 
     print("Cleaning sentences ...")
-    clean_sentences(input_path, output_path=output_path)
+    clean_sentences(input_path, output_path=output_path, err_path=err_path)

--- a/src/preprocess_dataset/clean_sentences.py
+++ b/src/preprocess_dataset/clean_sentences.py
@@ -26,8 +26,8 @@ def clean_sentences(input_path: str, output_path: str, err_path: str):
                     err_writer.writerow([i+1, *data])
 
             if i % 100 == 0:
-                sys.stdout.flush() # 明示的にflush
                 print(f"{datetime.datetime.now()}: {i} lines have been processed.")
+                sys.stdout.flush() # 明示的にflush
     print(f"Successfully dumped {output_path} !")
 
 

--- a/src/preprocess_dataset/clean_sentences.py
+++ b/src/preprocess_dataset/clean_sentences.py
@@ -5,6 +5,7 @@ import sys
 
 
 # 抽出文がないものを除外し、文末の改行コードを除去
+# TODO: [h, t, n, s]での出力 & nをキーに降順にソート
 def clean_sentences(input_path: str, output_path: str, err_path: str):
     with gzip.open(input_path, 'rt') as rf, \
         gzip.open(output_path, 'wt') as wf, \

--- a/src/preprocess_dataset/conceptnet_to_triplets.py
+++ b/src/preprocess_dataset/conceptnet_to_triplets.py
@@ -60,6 +60,7 @@ def conceptnet_to_triplets(input_path, output_path, removed_path, lang="ja"):
             writer.writerows(triplets)
 
 
+# トリプレットから単語の組を作成して出力する
 def make_word_pairs(input_path, output_path):
     word_pairs = set()
     with open(input_path, "r") as f:

--- a/src/preprocess_dataset/conceptnet_to_triplets.py
+++ b/src/preprocess_dataset/conceptnet_to_triplets.py
@@ -5,68 +5,83 @@ from extract_entity import extract_entity
 from normalize_neologd import normalize_neologd
 
 
-lang = "ja"
-dataset_dir = f"datasets/conceptnet-assertions-5.7.0/{lang}"
-input_path = f"conceptnet-assertions-5.7.0_{lang}.csv.gz"
-output_dir = dataset_dir
-output_path = f"{output_dir}/origin_triplets.csv"
-removed_path = f"{output_dir}/removed_triplets.csv.gz"
-conceptnet_path = f"{dataset_dir}/{input_path}"
+def conceptnet_to_triplets(input_path, output_path, removed_path, lang="ja"):
+    conceptnet = []
+    relations = []
+    with gzip.open(input_path, 'rt') as f:
+        reader = csv.reader(f, delimiter='\t')
+        for row in reader:
+            conceptnet.append(row[1:-1])  # relation と head と tail だけ取得
+            relations.append(row[1])
 
-conceptnet = []
-with gzip.open(conceptnet_path, 'rt') as f:
-    reader = csv.reader(f, delimiter='\t')
-    for row in reader:
-        conceptnet.append(row[1:-1])  # relation と head と tail だけ取得
+    # 例. relation_mapping["/r/RelatedTo"] = 関連する
+    # 参照. datasets/conceptnet-assertions-5.7.0/ja/relations.csv
+    relations_set = set(relations)
+    all_data = {relation_uri: [] for relation_uri in relations_set}
 
-# 例. relation_mapping["/r/RelatedTo"] = 関連する
-# 参照. datasets/conceptnet-assertions-5.7.0/ja/relations.csv
-relations_data_path = f"{dataset_dir}/relations.csv"
-with open(relations_data_path, 'r') as f:
-    reader = csv.reader(f)
-    header = next(reader)
-    relations_data = [row for row in reader]
-relation_mapping = {row[0]: row[2] for row in relations_data}
+    with gzip.open(removed_path, 'wt') as f:
+        writer = csv.writer(f)
+        for i, row in enumerate(conceptnet):
+            relation_uri = row[0]
 
-all_data = {relation_uri: [] for relation_uri in relation_mapping.keys()}
+            # `/r/ExternalURL` はデータセットに含めない
+            if relation_uri == "/r/ExternalURL":
+                continue
 
-with gzip.open(removed_path, 'wt') as f:
-    writer = csv.writer(f)
-    for i, row in enumerate(conceptnet):
-        relation_uri = row[0]
+            # `NotUsedFor`などの否定的な関係性は含めない
+            if "Not" in relation_uri:
+                continue
 
-        # `/r/ExternalURL` はデータセットに含めない
-        if relation_uri == "/r/ExternalURL":
-            continue
+            head = extract_entity(lang, row[1])
+            tail = extract_entity(lang, row[2])
+            if head == None or tail == None:
+                writer.writerow((i, *row[:]))
+                continue
 
-        # `NotUsedFor`などの否定的な関係性は含めない
-        if "Not" in relation_uri:
-            continue
+            # 正規化
+            head = normalize_neologd(head)
+            tail = normalize_neologd(tail)
+            # 例. "イタリアン_コーヒー" -> "イタリアンコーヒー"
+            if lang == "ja":
+                head = head.replace("_", "")
+                tail = tail.replace("_", "")
+            # 例. "New_York" -> "New York"
+            else:
+                head = head.replace("_", " ")
+                tail = tail.replace("_", " ")
 
-        head = extract_entity(lang, row[1])
-        tail = extract_entity(lang, row[2])
-        if head == None or tail == None:
-            writer.writerow((i, *row[:]))
-            continue
+            all_data[relation_uri].append([head, tail])
 
-        # 正規化
-        head = normalize_neologd(head)
-        tail = normalize_neologd(tail)
-        # 例. "イタリアン_コーヒー" -> "イタリアンコーヒー"
-        if lang == "ja":
-            head = head.replace("_", "")
-            tail = tail.replace("_", "")
-        # 例. "New_York" -> "New York"
-        else:
-            head = head.replace("_", " ")
-            tail = tail.replace("_", " ")
+    with open(output_path, 'w') as f:
+        writer = csv.writer(f)
+        for relation_uri, heads_and_tails in all_data.items():
+            # (relation, head, tail) のトリプレットを作成
+            triplets = [[relation_uri, pair[0], pair[1]] for pair in heads_and_tails]
+            writer.writerows(triplets)
 
-        all_data[relation_uri].append([head, tail])
 
-with open(output_path, 'w') as f:
-    writer = csv.writer(f)
-    for relation_uri, heads_and_tails in all_data.items():
-        # (relation, head, tail) のトリプレットを作成
-        triplets = [[relation_mapping[relation_uri], pair[0], pair[1]]
-                    for pair in heads_and_tails]
-        writer.writerows(triplets)
+def make_word_pairs(input_path, output_path):
+    word_pairs = set()
+    with open(input_path, "r") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            word_pair = tuple(sorted((row[1], row[2])))
+            word_pairs.add(word_pair)
+
+    with open(output_path, "w") as f:
+        writer = csv.writer(f)
+        writer.writerows(word_pairs)
+
+
+if __name__ == "__main__":
+    lang = "ja"
+    dataset_dir = f"datasets/conceptnet-assertions-5.7.0/{lang}"
+
+    input_path = f"{dataset_dir}/conceptnet-assertions-5.7.0_{lang}.csv.gz"
+    output_path = f"{dataset_dir}/origin_triplets.csv"
+    removed_path = f"{dataset_dir}/removed_triplets.csv.gz"
+    conceptnet_to_triplets(input_path, output_path, removed_path)
+
+    input_path = f"{dataset_dir}/origin_triplets.csv"
+    output_path = f"{dataset_dir}/origin_word_pairs.csv"
+    make_word_pairs(input_path, output_path)

--- a/src/preprocess_dataset/extract_sentences.py
+++ b/src/preprocess_dataset/extract_sentences.py
@@ -37,8 +37,8 @@ def extract_sentences(
                 writer_over.writerow(data)
 
             if i % 100 == 0:
-                sys.stdout.flush() # 明示的にflush
                 print(f"{datetime.datetime.now()}: {i} triplets have been processed.")
+                sys.stdout.flush() # 明示的にflush
     print(f"Successfully dumped {output_path} !")
 
 

--- a/src/preprocess_dataset/extract_sentences.py
+++ b/src/preprocess_dataset/extract_sentences.py
@@ -16,28 +16,25 @@ def extract_sentences(
         print(f"{datetime.datetime.now()}: Start")
         sys.stdout.flush()
 
-        word_pairs = set()
-
         for i, row in enumerate(conceptnet):
             head = row[1]
             tail = row[2]
-            word_pair = tuple(sorted((head, tail)))
 
-            if word_pair not in word_pairs:
-                word_pairs.add(word_pair)
-                sentences = []
-                for sentence in corpus:
-                    if head in sentence and tail in sentence:
-                        sentences.append(sentence)
-                        # if len(sentences) == num_extract:
-                        #     break
+            sentences = []
+            for sentence in corpus:
+                if head in sentence and tail in sentence:
+                    sentences.append(sentence)
+                    # if len(sentences) == num_extract:
+                    #     break
 
-                num_sentences = len(sentences)
-                data = (head, tail, num_sentences, sentences)
-                if num_sentences < 1000000:
-                    writer.writerow(data)
-                else:
-                    writer_over1m.writerow(data)
+            num_sentences = len(sentences)
+            data = (head, tail, num_sentences, sentences)
+
+            # 抽出文の総数があまりにも多い場合は別のファイルへ出力
+            if num_sentences < 1000000:
+                writer.writerow(data)
+            else:
+                writer_over1m.writerow(data)
 
             if i % 100 == 0:
                 sys.stdout.flush() # 明示的にflush

--- a/src/preprocess_dataset/extract_sentences.py
+++ b/src/preprocess_dataset/extract_sentences.py
@@ -9,7 +9,7 @@ def extract_sentences(
         over_path: str,
         corpus: list,
         conceptnet: list,
-        extract_limit: int = 1000000) -> None:
+        extract_limit: int = 200000) -> None:
     with gzip.open(output_path, "wt") as f, gzip.open(over_path, "wt") as f_over:
         writer = csv.writer(f)
         writer_over = csv.writer(f_over)

--- a/src/preprocess_dataset/extract_sentences.py
+++ b/src/preprocess_dataset/extract_sentences.py
@@ -6,13 +6,13 @@ import sys
 
 def extract_sentences(
         output_path: str,
-        over1m_path: str,
+        over_path: str,
         corpus: list,
         conceptnet: list,
-        num_extract: int = 5) -> None:
-    with gzip.open(output_path, "wt") as f, gzip.open(over1m_path, "wt") as f1m:
+        extract_limit: int = 1000000) -> None:
+    with gzip.open(output_path, "wt") as f, gzip.open(over_path, "wt") as f_over:
         writer = csv.writer(f)
-        writer_over1m = csv.writer(f1m)
+        writer_over = csv.writer(f_over)
         print(f"{datetime.datetime.now()}: Start")
         sys.stdout.flush()
 
@@ -24,17 +24,17 @@ def extract_sentences(
             for sentence in corpus:
                 if head in sentence and tail in sentence:
                     sentences.append(sentence)
-                    # if len(sentences) == num_extract:
-                    #     break
+                    if len(sentences) == extract_limit:
+                        break
 
             num_sentences = len(sentences)
             data = (head, tail, num_sentences, sentences)
 
             # 抽出文の総数があまりにも多い場合は別のファイルへ出力
-            if num_sentences < 1000000:
+            if num_sentences < extract_limit:
                 writer.writerow(data)
             else:
-                writer_over1m.writerow(data)
+                writer_over.writerow(data)
 
             if i % 100 == 0:
                 sys.stdout.flush() # 明示的にflush
@@ -71,11 +71,11 @@ if __name__ == "__main__":
 
     output_dir = "datasets/rel_gen/origin_rhts"
     output_corpus_path = f"{output_dir}/origin_htns_200_{dataset_type}.csv.gz"
-    output_over1m_path = f"{output_dir}/origin_htns_200_{dataset_type}_over1m.csv.gz"
+    output_over_path = f"{output_dir}/origin_htns_200_{dataset_type}_over.csv.gz"
 
     print("Extracting sentences ...")
     extract_sentences(output_path=output_corpus_path,
-                      over1m_path=output_over1m_path,
+                      over_path=output_over_path,
                       corpus=corpus,
                       conceptnet=conceptnet)
 

--- a/src/preprocess_dataset/tokenizing_filter.py
+++ b/src/preprocess_dataset/tokenizing_filter.py
@@ -5,15 +5,18 @@ import sys
 import os
 
 
-dic = "jumanpp"
-assert dic in ["ipadic", "neologd", "jumanpp"]
-if dic == "ipadic":
-    import MeCab
-    tokenizer = MeCab.Tagger("-d /usr/local/lib/mecab/dic/ipadic")
-elif dic == "neologd":
-    import MeCab
-    tokenizer = MeCab.Tagger("-d /usr/local/lib/mecab/dic/mecab-ipadic-neologd")
-elif dic == "jumanpp":
+tokenizer_type = "jumanpp"
+dic = ""
+assert tokenizer_type in ["jumanpp", "mecab"]
+if tokenizer_type == "mecab":
+    assert dic in ["ipadic", "neologd"]
+    if dic == "ipadic":
+        import MeCab
+        tokenizer = MeCab.Tagger("-d /usr/local/lib/mecab/dic/ipadic")
+    elif dic == "neologd":
+        import MeCab
+        tokenizer = MeCab.Tagger("-d /usr/local/lib/mecab/dic/mecab-ipadic-neologd")
+elif tokenizer_type == "jumanpp":
     from transformers import AutoTokenizer
     tokenizer = AutoTokenizer.from_pretrained("nlp-waseda/roberta-base-japanese-with-auto-jumanpp")
 

--- a/src/preprocess_dataset/tokenizing_filter.py
+++ b/src/preprocess_dataset/tokenizing_filter.py
@@ -46,13 +46,13 @@ def tokenizing_filter(input_path: str, output_path: str, removed_path: str, dic=
 
             for i, row in enumerate(reader):
                 sentences = eval(row[-1])
-                if dic == "jumanpp":
-                    tokenized_head = tokenize_juman(row[1])
-                    tokenized_tail = tokenize_juman(row[2])
+                if tokenizer_type == "jumanpp":
+                    tokenized_head = tokenize_juman(row[0])
+                    tokenized_tail = tokenize_juman(row[1])
                     tokenized_sentences = map(tokenize_juman, sentences)
-                elif dic in ["ipadic", "neologd"]:
-                    tokenized_head = tokenize_mecab(row[1])
-                    tokenized_tail = tokenize_mecab(row[2])
+                elif tokenizer_type == ["mecab"]:
+                    tokenized_head = tokenize_mecab(row[0])
+                    tokenized_tail = tokenize_mecab(row[1])
                     tokenized_sentences = map(tokenize_mecab, sentences)
 
                 search_targets = [*tokenized_head, *tokenized_tail]

--- a/src/preprocess_dataset/tokenizing_filter.py
+++ b/src/preprocess_dataset/tokenizing_filter.py
@@ -83,12 +83,12 @@ if __name__ == "__main__":
 
     dataset_type = "1"
     input_dir = "datasets/rel_gen/cleaned_rhts"
-    input_path = f"{input_dir}/cleaned_rhts_200_{dataset_type}.csv.gz"
-    output_dir = f"datasets/rel_gen/{dic}_rhts"
+    input_path = f"{input_dir}/cleaned_htns_200_{dataset_type}.csv.gz"
+    output_dir = f"datasets/rel_gen/{dic}_htns"
     if not os.path.isdir(output_dir):
         os.makedirs(output_dir)
-    output_path = f"{output_dir}/filtered_rhts_200_{dataset_type}.csv.gz"
-    removed_path = f"{output_dir}/removed_rhts_200_{dataset_type}.csv.gz"
+    output_path = f"{output_dir}/filtered_htns_200_{dataset_type}.csv.gz"
+    removed_path = f"{output_dir}/removed_htns_200_{dataset_type}.csv.gz"
 
     print("Filtering sentences ...")
     tokenizing_filter(input_path, output_path, removed_path, dic="jumanpp")

--- a/src/preprocess_dataset/tokenizing_filter.py
+++ b/src/preprocess_dataset/tokenizing_filter.py
@@ -40,7 +40,7 @@ def _check_all_elements(targets: list, sentence: list):
     return all(target in sentence for target in targets)
 
 
-def tokenizing_filter(input_path: str, output_path: str, removed_path: str, dic="jumanpp"):
+def tokenizing_filter(input_path: str, output_path: str, removed_path: str, tokenizer_type="jumanpp"):
     with gzip.open(output_path, 'wt') as wf, gzip.open(removed_path, 'wt') as removed_f:
         writer = csv.writer(wf)
         removed_writer = csv.writer(removed_f)
@@ -84,11 +84,11 @@ if __name__ == "__main__":
     dataset_type = "1"
     input_dir = "datasets/rel_gen/cleaned_rhts"
     input_path = f"{input_dir}/cleaned_htns_200_{dataset_type}.csv.gz"
-    output_dir = f"datasets/rel_gen/{dic}_htns"
+    output_dir = f"datasets/rel_gen/{tokenizer_type}_htns"
     if not os.path.isdir(output_dir):
         os.makedirs(output_dir)
     output_path = f"{output_dir}/filtered_htns_200_{dataset_type}.csv.gz"
     removed_path = f"{output_dir}/removed_htns_200_{dataset_type}.csv.gz"
 
     print("Filtering sentences ...")
-    tokenizing_filter(input_path, output_path, removed_path, dic="jumanpp")
+    tokenizing_filter(input_path, output_path, removed_path, tokenizer_type="jumanpp")

--- a/src/preprocess_dataset/tokenizing_filter.py
+++ b/src/preprocess_dataset/tokenizing_filter.py
@@ -50,30 +50,32 @@ def tokenizing_filter(input_path: str, output_path: str, removed_path: str, toke
             for i, row in enumerate(reader):
                 sentences = eval(row[-1])
                 if tokenizer_type == "jumanpp":
-                    tokenized_head = tokenize_juman(row[0])
-                    tokenized_tail = tokenize_juman(row[1])
+                    tokenized_word1 = tokenize_juman(row[0])
+                    tokenized_word2 = tokenize_juman(row[1])
                     tokenized_sentences = map(tokenize_juman, sentences)
                 elif tokenizer_type == ["mecab"]:
-                    tokenized_head = tokenize_mecab(row[0])
-                    tokenized_tail = tokenize_mecab(row[1])
+                    tokenized_word1 = tokenize_mecab(row[0])
+                    tokenized_word2 = tokenize_mecab(row[1])
                     tokenized_sentences = map(tokenize_mecab, sentences)
 
-                search_targets = [*tokenized_head, *tokenized_tail]
+                search_target_tokens = [*tokenized_word1, *tokenized_word2]
                 filtered_sentences = []
                 removed_sentences = []
 
                 for j, tokenized_sentence in enumerate(tokenized_sentences):
-                    if _check_all_elements(search_targets, tokenized_sentence):
+                    if _check_all_elements(search_target_tokens, tokenized_sentence):
                         filtered_sentences.append(sentences[j])
                     else:
                         removed_sentences.append(sentences[j])
 
-                writer.writerow([*row[:-1], filtered_sentences])
-                removed_writer.writerow([*row[:-1], removed_sentences])
+                writer.writerow([row[0], row[1], len(filtered_sentences), filtered_sentences])
+                removed_writer.writerow([row[0], row[1], len(removed_sentences), removed_sentences])
 
                 if i % 100 == 0:
                     print(f"{datetime.datetime.now()}: {i} lines have been processed.")
                     sys.stdout.flush() # 明示的にflush
+
+    print(f"Successfully dumped {output_path} !")
 
 
 if __name__ == "__main__":
@@ -90,5 +92,6 @@ if __name__ == "__main__":
     output_path = f"{output_dir}/filtered_htns_200_{dataset_type}.csv.gz"
     removed_path = f"{output_dir}/removed_htns_200_{dataset_type}.csv.gz"
 
-    print("Filtering sentences ...")
+    print(f"{datetime.datetime.now()}: Filtering sentences ...")
+    sys.stdout.flush() # 明示的にflush
     tokenizing_filter(input_path, output_path, removed_path, tokenizer_type="jumanpp")

--- a/src/preprocess_dataset/tokenizing_filter.py
+++ b/src/preprocess_dataset/tokenizing_filter.py
@@ -1,0 +1,91 @@
+import csv
+import gzip
+import datetime
+import sys
+import os
+
+
+dic = "jumanpp"
+assert dic in ["ipadic", "neologd", "jumanpp"]
+if dic == "ipadic":
+    import MeCab
+    tokenizer = MeCab.Tagger("-d /usr/local/lib/mecab/dic/ipadic")
+elif dic == "neologd":
+    import MeCab
+    tokenizer = MeCab.Tagger("-d /usr/local/lib/mecab/dic/mecab-ipadic-neologd")
+elif dic == "jumanpp":
+    from transformers import AutoTokenizer
+    tokenizer = AutoTokenizer.from_pretrained("nlp-waseda/roberta-base-japanese-with-auto-jumanpp")
+
+
+def tokenize_mecab(text:str) -> list:
+    result = tokenizer.parse(text)
+
+    # 分かち書きされた文を抽出
+    lines = result.split('\n')
+    words = [line.split('\t')[0] for line in lines[:-2]]
+
+    return words
+
+
+def tokenize_juman(text:str) -> list:
+    return tokenizer.tokenize(text)
+
+
+# 全てのターゲットトークンが対象の文に含まれていればTrueを返す
+def _check_all_elements(targets: list, sentence: list):
+    return all(target in sentence for target in targets)
+
+
+def tokenizing_filter(input_path: str, output_path: str, removed_path: str, dic="jumanpp"):
+    with gzip.open(output_path, 'wt') as wf, gzip.open(removed_path, 'wt') as removed_f:
+        writer = csv.writer(wf)
+        removed_writer = csv.writer(removed_f)
+        with gzip.open(input_path, 'rt') as rf:
+            reader = csv.reader(rf)
+
+            for i, row in enumerate(reader):
+                sentences = eval(row[-1])
+                if dic == "jumanpp":
+                    tokenized_head = tokenize_juman(row[1])
+                    tokenized_tail = tokenize_juman(row[2])
+                    tokenized_sentences = map(tokenize_juman, sentences)
+                elif dic in ["ipadic", "neologd"]:
+                    tokenized_head = tokenize_mecab(row[1])
+                    tokenized_tail = tokenize_mecab(row[2])
+                    tokenized_sentences = map(tokenize_mecab, sentences)
+
+                search_targets = [*tokenized_head, *tokenized_tail]
+                filtered_sentences = []
+                removed_sentences = []
+
+                for j, tokenized_sentence in enumerate(tokenized_sentences):
+                    if _check_all_elements(search_targets, tokenized_sentence):
+                        filtered_sentences.append(sentences[j])
+                    else:
+                        removed_sentences.append(sentences[j])
+
+                writer.writerow([*row[:-1], filtered_sentences])
+                removed_writer.writerow([*row[:-1], removed_sentences])
+
+                if i % 100 == 0:
+                    sys.stdout.flush() # 明示的にflush
+                    print(f"{datetime.datetime.now()}: {i} lines have been processed.")
+
+
+if __name__ == "__main__":
+    # 20GBまでのcsvファイルを扱えるようにフィールドサイズ制限を増やす
+    gb_to_bytes = 20 * 1024 * 1024 * 1024
+    csv.field_size_limit(gb_to_bytes)
+
+    dataset_type = "1"
+    input_dir = "datasets/rel_gen/cleaned_rhts"
+    input_path = f"{input_dir}/cleaned_rhts_200_{dataset_type}.csv.gz"
+    output_dir = f"datasets/rel_gen/{dic}_rhts"
+    if not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    output_path = f"{output_dir}/filtered_rhts_200_{dataset_type}.csv.gz"
+    removed_path = f"{output_dir}/removed_rhts_200_{dataset_type}.csv.gz"
+
+    print("Filtering sentences ...")
+    tokenizing_filter(input_path, output_path, removed_path, dic="jumanpp")

--- a/src/preprocess_dataset/tokenizing_filter.py
+++ b/src/preprocess_dataset/tokenizing_filter.py
@@ -72,8 +72,8 @@ def tokenizing_filter(input_path: str, output_path: str, removed_path: str, dic=
                 removed_writer.writerow([*row[:-1], removed_sentences])
 
                 if i % 100 == 0:
-                    sys.stdout.flush() # 明示的にflush
                     print(f"{datetime.datetime.now()}: {i} lines have been processed.")
+                    sys.stdout.flush() # 明示的にflush
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- 抽出した文の数が200,000を超えるものはサイズが膨大にも関わらず、学習の妨げになるような語の組（例. `の` と `が`）ばかりだったので、排除した
- (`犬`, `猫`) と (`猫`, `犬`) のような組み合わせが同じものは、文の抽出において差別化する必要がないため、重複を排除した